### PR TITLE
make-envers-cross-project-usuable

### DIFF
--- a/oapenwb-javalin/sql/init.sql
+++ b/oapenwb-javalin/sql/init.sql
@@ -40,6 +40,7 @@ create table Violation (ip varchar(45) not null, whenTS timestamp not null, info
 create table RevInfos (
 	id int8 not null,
 	timestamp int8 not null,
+	platform varchar(8) not null,
 	userID int4,
 	comment varchar(384),
 	primary key (id)

--- a/oapenwb-javalin/src/main/java/dk/ule/oapenwb/data/HibernateConfiguratorImpl.java
+++ b/oapenwb-javalin/src/main/java/dk/ule/oapenwb/data/HibernateConfiguratorImpl.java
@@ -4,6 +4,7 @@ package dk.ule.oapenwb.data;
 
 import dk.ule.oapenwb.base.AppConfig;
 import dk.ule.oapenwb.base.RunMode;
+import dk.ule.oapenwb.entity.auditing.UserRevisionEntity;
 import dk.ule.oapenwb.entity.basis.*;
 import dk.ule.oapenwb.entity.statistics.CondensedData;
 import dk.ule.oapenwb.entity.statistics.SearchRun;
@@ -29,8 +30,8 @@ import org.hibernate.cfg.Configuration;
  */
 public class HibernateConfiguratorImpl implements HibernateConfigurator
 {
-	private RunMode runMode;
-	private AppConfig appConfig;
+	private final RunMode runMode;
+	private final AppConfig appConfig;
 	@Getter @Setter
 	private boolean createTables = false;
 
@@ -41,17 +42,11 @@ public class HibernateConfiguratorImpl implements HibernateConfigurator
 
 	@Override
 	public String getHibernateConfigFile() {
-		switch (this.runMode) {
-			case Normal:
-			default:
-				return "/hibernate.prod.cfg.xml";
-
-			case Development:
-				return "/hibernate.dev.cfg.xml";
-
-			case Testing:
-				return "/hibernate.testing.cfg.xml";
-		}
+		return switch (this.runMode) {
+			default -> "/hibernate.prod.cfg.xml";
+			case Development -> "/hibernate.dev.cfg.xml";
+			case Testing -> "/hibernate.testing.cfg.xml";
+		};
 	}
 
 	@Override
@@ -62,21 +57,21 @@ public class HibernateConfiguratorImpl implements HibernateConfigurator
 		configuration.setProperty(AvailableSettings.FORMAT_SQL,
 				this.appConfig.getDbConfig().isShowSQL() ? "true" : "false");
 
-		configuration.setProperty(AvailableSettings.URL, this.buildConnectionURL());
-		configuration.setProperty(AvailableSettings.USER, this.appConfig.getDbConfig().getUsername());
-		configuration.setProperty(AvailableSettings.PASS, this.appConfig.getDbConfig().getPassword());
+		configuration.setProperty(AvailableSettings.JAKARTA_JDBC_URL, this.buildConnectionURL());
+		configuration.setProperty(AvailableSettings.JAKARTA_JDBC_USER, this.appConfig.getDbConfig().getUsername());
+		configuration.setProperty(AvailableSettings.JAKARTA_JDBC_PASSWORD, this.appConfig.getDbConfig().getPassword());
 	}
 
 	@Override
 	public void configurate(Configuration configuration) {
 		configurateMinimal(configuration);
 
+		/* TODO Hibernate shall not anymore create the tables etc., it is done manually
+			   by the initialization script for now.
 		if (this.isCreateTables()) {
-			/* TODO Hibernate shall not anymore create the tables etc., it is done manually
-			   by the initialization script for now. */
 			//configuration.setProperty(AvailableSettings.HBM2DDL_DATABASE_ACTION, "create");
 			//configuration.setProperty(AvailableSettings.HBM2DDL_AUTO, "update");
-		}
+		} */
 
 		// Minimal number of idle connections in the pool
 		configuration.setProperty("hibernate.hikari.minimumIdle",

--- a/oapenwb-javalin/src/main/java/dk/ule/oapenwb/data/UserRevisionListener.java
+++ b/oapenwb-javalin/src/main/java/dk/ule/oapenwb/data/UserRevisionListener.java
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: © 2022 Michael Köther <mkoether38@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-only
+
 package dk.ule.oapenwb.data;
 
-import dk.ule.oapenwb.entity.basis.UserRevisionEntity;
+import dk.ule.oapenwb.entity.auditing.UserRevisionEntity;
 import dk.ule.oapenwb.util.CurrentUser;
 import dk.ule.oapenwb.util.HibernateUtil;
 import org.hibernate.envers.RevisionListener;
@@ -16,6 +17,7 @@ public class UserRevisionListener implements RevisionListener
 	public void newRevision(Object revisionEntity)
 	{
 		UserRevisionEntity revEntity = (UserRevisionEntity) revisionEntity;
+		revEntity.setPlatform(UserRevisionEntity.PLATFORM_JAVALIN);
 		revEntity.setUserID(CurrentUser.INSTANCE.get());
 		revEntity.setComment(HibernateUtil.getRevisionComment());
 	}

--- a/oapenwb-javalin/src/main/java/dk/ule/oapenwb/entity/auditing/UserRevisionEntity.java
+++ b/oapenwb-javalin/src/main/java/dk/ule/oapenwb/entity/auditing/UserRevisionEntity.java
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 Michael Köther <mkoether38@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-only
-package dk.ule.oapenwb.entity.basis;
+
+package dk.ule.oapenwb.entity.auditing;
 
 import dk.ule.oapenwb.data.UserRevisionListener;
 import jakarta.persistence.*;
@@ -10,7 +11,12 @@ import org.hibernate.envers.RevisionNumber;
 import org.hibernate.envers.RevisionTimestamp;
 
 /**
- * RevisionEntity for the revisions of data changes in the audited entities.
+ * <p>RevisionEntity for the revisions of data changes in the audited entities.</p>
+ *
+ * <p>This entity is defined in each of the currently two platforms (<b>oapenwb-javalin</b> and
+ * <b>oapenwb-spring</b>). Both entities are mapped for the exact same table and with the exact
+ * same columns. The difference, however, is that each of the two entities uses a different
+ * RevisionListener which is platform specific.</p>
  */
 @Data
 @Entity
@@ -18,6 +24,8 @@ import org.hibernate.envers.RevisionTimestamp;
 @RevisionEntity(UserRevisionListener.class)
 public class UserRevisionEntity /*extends DefaultRevisionEntity*/
 {
+	public static final String PLATFORM_JAVALIN = "javalin";
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "revision_seq")
 	@SequenceGenerator(name = "revision_seq", sequenceName = "revision_seq", allocationSize = 10)
@@ -25,7 +33,12 @@ public class UserRevisionEntity /*extends DefaultRevisionEntity*/
 	private long id;
 
 	@RevisionTimestamp
+	@Column(nullable = false)
 	private long timestamp;
+
+	/** Should be the name of the platform, e.g. "javalin" or "spring" */
+	@Column(length = 8, nullable = false)
+	private String platform;
 
 	@Column
 	private Integer userID;

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/config/persistence/PersistenceConfig.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/config/persistence/PersistenceConfig.java
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.config.persistence;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.annotation.RequestScope;
+
+import dk.ule.oapenwb2.persistence.UserRevisionListener;
+
+@Configuration
+@EntityScan(basePackages = {"dk.ule.oapenwb2.persistence", "dk.ule.oapenwb.persistency.entity"})
+public class PersistenceConfig
+{
+	/**
+	 * <p>Bean to store and access revision related information within request scope. This will be used by
+	 * {@link UserRevisionListener} when writing new revisions.</p>
+	 *
+	 * @return the revision info bean
+	 */
+	@Bean
+	@RequestScope
+	public RevisionInfo revisionInfo() {
+		return new RevisionInfo();
+	}
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/config/persistence/RevisionInfo.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/config/persistence/RevisionInfo.java
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.config.persistence;
+
+import lombok.Data;
+
+@Data
+public class RevisionInfo
+{
+	private Integer activeUserID;
+	private String revisionComment;
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/UserRevisionListener.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/UserRevisionListener.java
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.persistence;
+
+import dk.ule.oapenwb2.config.persistence.RevisionInfo;
+import dk.ule.oapenwb2.persistence.auditing.UserRevisionEntity;
+import org.hibernate.envers.RevisionListener;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * This implementation of a {@link RevisionListener} will add a userID and a revision comment
+ * for every commit.
+ */
+public class UserRevisionListener implements RevisionListener
+{
+	@Autowired
+	private RevisionInfo revisionInfo;
+
+	public void newRevision(Object revisionEntity) {
+		final UserRevisionEntity revEntity = (UserRevisionEntity) revisionEntity;
+		revEntity.setPlatform(UserRevisionEntity.PLATFORM_SPRING);
+		revEntity.setUserID(revisionInfo.getActiveUserID());
+		revEntity.setComment(revisionInfo.getRevisionComment());
+	}
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/auditing/UserRevisionEntity.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/auditing/UserRevisionEntity.java
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.persistence.auditing;
+
+import dk.ule.oapenwb2.persistence.UserRevisionListener;
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.envers.RevisionEntity;
+import org.hibernate.envers.RevisionNumber;
+import org.hibernate.envers.RevisionTimestamp;
+
+/**
+ * <p>RevisionEntity for the revisions of data changes in the audited entities.</p>
+ *
+ * <p>This entity is defined in each of the currently two platforms (<b>oapenwb-javalin</b> and
+ * <b>oapenwb-spring</b>). Both entities are mapped for the exact same table and with the exact
+ * same columns. The difference, however, is that each of the two entities uses a different
+ * RevisionListener which is platform specific.</p>
+ */
+@Data
+@Entity
+@Table(name = "RevInfos")
+@RevisionEntity(UserRevisionListener.class)
+public class UserRevisionEntity
+{
+	public static final String PLATFORM_SPRING = "spring";
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "revision_seq")
+	@SequenceGenerator(name = "revision_seq", sequenceName = "revision_seq", allocationSize = 10)
+	@RevisionNumber
+	private long id;
+
+	@RevisionTimestamp
+	@Column(nullable = false)
+	private long timestamp;
+
+	/** Should be the name of the platform, e.g. "javalin" or "spring" */
+	@Column(length = 8, nullable = false)
+	private String platform;
+
+	@Column
+	private Integer userID;
+
+	@Column(length = 384)
+	private String comment;
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/CategoryRepository.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/CategoryRepository.java
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.persistence.content.basedata;
+
+import dk.ule.oapenwb.persistency.entity.content.basedata.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Integer>
+{
+}

--- a/oapenwb-spring/src/main/resources/application.yml
+++ b/oapenwb-spring/src/main/resources/application.yml
@@ -8,7 +8,12 @@ server:
 spring:
     application:
         name: 'oapenwb-spring'
-    liquibase:
-        enabled: false
     datasource:
         url: jdbc:postgresql://host:port/database_name
+    jpa:
+        hibernate:
+            naming:
+                physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+                implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
+    liquibase:
+        enabled: false


### PR DESCRIPTION
oapenwb-javalin:
- Moved UserRevisionEntity.
- Added new column platform to UserRevisionEntity.
- Extended UserRevisionListener to fill new platform on revision entity.
- Minor optimizations in HibernateConfiguratorImpl.

oapenwb-spring:
- Change hibernate naming strategies to be JPA 1-like.
- Implemented UserRevisionEntity and UserRevisionListener similar to oapenwb-javalin, but with necessary changes to fit oapenwb-spring project (including PersistenceConfig and the RevisionInfo bean).
- Added first JPA repository for entity Category. The repository was used for a first test controller.