### PR TITLE
add-endpoints-for-abbreviations-site

### DIFF
--- a/oapenwb-spring/pom.xml
+++ b/oapenwb-spring/pom.xml
@@ -37,6 +37,7 @@
 
 	<properties>
 		<java.version>21</java.version>
+		<org.mapstruct.version>1.6.0</org.mapstruct.version>
 	</properties>
 
 	<dependencies>
@@ -85,6 +86,18 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>${org.mapstruct.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok-mapstruct-binding</artifactId>
+			<version>0.2.0</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -104,6 +117,25 @@
 							<artifactId>lombok</artifactId>
 						</exclude>
 					</excludes>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<source>1.8</source> <!-- depending on your project -->
+					<target>1.8</target> <!-- depending on your project -->
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${org.mapstruct.version}</version>
+						</path>
+
+						<!-- other annotation processors -->
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/oapenwb-spring/pom.xml
+++ b/oapenwb-spring/pom.xml
@@ -38,6 +38,7 @@
 	<properties>
 		<java.version>21</java.version>
 		<org.mapstruct.version>1.6.0</org.mapstruct.version>
+		<lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
 	</properties>
 
 	<dependencies>
@@ -95,7 +96,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok-mapstruct-binding</artifactId>
-			<version>0.2.0</version>
+			<version>${lombok-mapstruct-binding.version}</version>
 		</dependency>
 
 		<dependency>
@@ -123,10 +124,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.13.0</version>
 				<configuration>
-					<source>1.8</source> <!-- depending on your project -->
-					<target>1.8</target> <!-- depending on your project -->
+					<source>${java.version}</source>
+					<target>${java.version}</target>
 					<annotationProcessorPaths>
 						<path>
 							<groupId>org.mapstruct</groupId>
@@ -134,7 +135,17 @@
 							<version>${org.mapstruct.version}</version>
 						</path>
 
-						<!-- other annotation processors -->
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok-mapstruct-binding</artifactId>
+							<version>${lombok-mapstruct-binding.version}</version>
+						</path>
 					</annotationProcessorPaths>
 				</configuration>
 			</plugin>

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/AbbreviationsController.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/AbbreviationsController.java
@@ -3,9 +3,13 @@
 
 package dk.ule.oapenwb2.api.v1.abbreviations;
 
+import dk.ule.oapenwb.persistency.entity.content.basedata.Category;
 import dk.ule.oapenwb.persistency.entity.content.basedata.Language;
+import dk.ule.oapenwb2.api.v1.abbreviations.domain.CategoryDto;
 import dk.ule.oapenwb2.api.v1.abbreviations.domain.LanguageDto;
+import dk.ule.oapenwb2.api.v1.abbreviations.mapper.CategoryMapper;
 import dk.ule.oapenwb2.api.v1.abbreviations.mapper.LanguageMapper;
+import dk.ule.oapenwb2.service.content.CategoryService;
 import dk.ule.oapenwb2.service.content.LanguageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,9 +26,18 @@ public class AbbreviationsController
 	private final LanguageMapper languageMapper;
 	private final LanguageService languageService;
 
+	private final CategoryMapper categoryMapper;
+	private final CategoryService categoryService;
+
 	@GetMapping(path = "languages")
 	public List<LanguageDto> allLanguages() {
-		final List<Language> languageList = this.languageService.getAllLanguages();
+		final List<Language> languageList = languageService.getAllLanguages();
 		return languageMapper.mapLanguageList(languageList);
+	}
+
+	@GetMapping(path = "categories")
+	public List<CategoryDto> allCategories() {
+		final List<Category> categoryList = categoryService.getAllTopLevelCategories();
+		return categoryMapper.mapCategoryList(categoryList);
 	}
 }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/AbbreviationsController.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/AbbreviationsController.java
@@ -5,12 +5,16 @@ package dk.ule.oapenwb2.api.v1.abbreviations;
 
 import dk.ule.oapenwb.persistency.entity.content.basedata.Category;
 import dk.ule.oapenwb.persistency.entity.content.basedata.Language;
+import dk.ule.oapenwb.persistency.entity.content.basedata.Level;
 import dk.ule.oapenwb2.api.v1.abbreviations.domain.CategoryDto;
 import dk.ule.oapenwb2.api.v1.abbreviations.domain.LanguageDto;
+import dk.ule.oapenwb2.api.v1.abbreviations.domain.LevelDto;
 import dk.ule.oapenwb2.api.v1.abbreviations.mapper.CategoryMapper;
 import dk.ule.oapenwb2.api.v1.abbreviations.mapper.LanguageMapper;
+import dk.ule.oapenwb2.api.v1.abbreviations.mapper.LevelMapper;
 import dk.ule.oapenwb2.service.content.CategoryService;
 import dk.ule.oapenwb2.service.content.LanguageService;
+import dk.ule.oapenwb2.service.content.LevelService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,11 +27,19 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AbbreviationsController
 {
-	private final LanguageMapper languageMapper;
-	private final LanguageService languageService;
-
 	private final CategoryMapper categoryMapper;
+	private final LanguageMapper languageMapper;
+	private final LevelMapper levelMapper;
+
 	private final CategoryService categoryService;
+	private final LanguageService languageService;
+	private final LevelService levelService;
+
+	@GetMapping(path = "categories")
+	public List<CategoryDto> allCategories() {
+		final List<Category> categoryList = categoryService.getAllTopLevelCategories();
+		return categoryMapper.mapCategoryList(categoryList);
+	}
 
 	@GetMapping(path = "languages")
 	public List<LanguageDto> allLanguages() {
@@ -35,9 +47,9 @@ public class AbbreviationsController
 		return languageMapper.mapLanguageList(languageList);
 	}
 
-	@GetMapping(path = "categories")
-	public List<CategoryDto> allCategories() {
-		final List<Category> categoryList = categoryService.getAllTopLevelCategories();
-		return categoryMapper.mapCategoryList(categoryList);
+	@GetMapping(path = "levels")
+	public List<LevelDto> allLevels() {
+		final List<Level> levelList = levelService.getAllLevels();
+		return levelMapper.mapLevelList(levelList);
 	}
 }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/AbbreviationsController.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/AbbreviationsController.java
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.api.v1.abbreviations;
+
+import dk.ule.oapenwb.persistency.entity.content.basedata.Language;
+import dk.ule.oapenwb2.api.v1.abbreviations.domain.LanguageDto;
+import dk.ule.oapenwb2.api.v1.abbreviations.mapper.LanguageMapper;
+import dk.ule.oapenwb2.service.content.LanguageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("abbreviations")
+@RequiredArgsConstructor
+public class AbbreviationsController
+{
+	private final LanguageMapper languageMapper;
+	private final LanguageService languageService;
+
+	@GetMapping(path = "languages")
+	public List<LanguageDto> allLanguages() {
+		final List<Language> languageList = this.languageService.getAllLanguages();
+		return languageMapper.map(languageList);
+	}
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/AbbreviationsController.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/AbbreviationsController.java
@@ -25,6 +25,6 @@ public class AbbreviationsController
 	@GetMapping(path = "languages")
 	public List<LanguageDto> allLanguages() {
 		final List<Language> languageList = this.languageService.getAllLanguages();
-		return languageMapper.map(languageList);
+		return languageMapper.mapLanguageList(languageList);
 	}
 }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/domain/CategoryDto.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/domain/CategoryDto.java
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.api.v1.abbreviations.domain;
+
+public record CategoryDto(
+	String uitId,
+	String abbreviatedUitId
+	// TODO kinder-elementen bydoon?
+) { }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/domain/LanguageDto.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/domain/LanguageDto.java
@@ -9,5 +9,6 @@ public record LanguageDto(
 	String ownName,
 	String uitId,
 	String uitIdAbbr,
-	List<LanguageDto> dialects
+	List<LanguageDto> dialects,
+	List<OrthographyDto> orthographies
 ) { }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/domain/LanguageDto.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/domain/LanguageDto.java
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.api.v1.abbreviations.domain;
+
+import java.util.List;
+
+public record LanguageDto(
+	String ownName,
+	String uitId,
+	String uitIdAbbr,
+	List<LanguageDto> dialects
+) { }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/domain/LevelDto.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/domain/LevelDto.java
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.api.v1.abbreviations.domain;
+
+public record LevelDto(
+	String abbreviatedUitId,
+	String uitId
+) { }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/domain/OrthographyDto.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/domain/OrthographyDto.java
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.api.v1.abbreviations.domain;
+
+public record OrthographyDto(
+	String abbreviation,
+	String uitId
+) { }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/mapper/CategoryMapper.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/mapper/CategoryMapper.java
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.api.v1.abbreviations.mapper;
+
+import dk.ule.oapenwb.persistency.entity.content.basedata.Category;
+import dk.ule.oapenwb2.api.v1.abbreviations.domain.CategoryDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface CategoryMapper
+{
+	@Mapping(target = "uitId", source = "uitID")
+	@Mapping(target = "abbreviatedUitId", source = "uitID_abbr")
+	CategoryDto map(Category category);
+
+	List<CategoryDto> mapCategoryList(List<Category> categoryList);
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/mapper/LanguageMapper.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/mapper/LanguageMapper.java
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.api.v1.abbreviations.mapper;
+
+import dk.ule.oapenwb.persistency.entity.content.basedata.Language;
+import dk.ule.oapenwb2.api.v1.abbreviations.domain.LanguageDto;
+import dk.ule.oapenwb2.service.content.LanguageService;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public abstract class LanguageMapper
+{
+	@Autowired
+	protected LanguageService languageService;
+
+	@Mapping(target = "ownName", source = "localName")
+	@Mapping(target = "uitId", source = "uitID")
+	@Mapping(target = "uitIdAbbr", source = "uitID_abbr")
+	@Mapping(target = "dialects", expression = "java(this.map(languageService.getDialectsFor(language)))")
+	public abstract LanguageDto map(Language language);
+
+	public abstract List<LanguageDto> map(List<Language> languageList);
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/mapper/LanguageMapper.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/mapper/LanguageMapper.java
@@ -6,6 +6,7 @@ package dk.ule.oapenwb2.api.v1.abbreviations.mapper;
 import dk.ule.oapenwb.persistency.entity.content.basedata.Language;
 import dk.ule.oapenwb2.api.v1.abbreviations.domain.LanguageDto;
 import dk.ule.oapenwb2.service.content.LanguageService;
+import dk.ule.oapenwb2.service.content.OrthographyService;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -19,11 +20,15 @@ public abstract class LanguageMapper
 	@Autowired
 	protected LanguageService languageService;
 
+	@Autowired
+	protected OrthographyService orthographyService;
+
 	@Mapping(target = "ownName", source = "localName")
 	@Mapping(target = "uitId", source = "uitID")
 	@Mapping(target = "uitIdAbbr", source = "uitID_abbr")
-	@Mapping(target = "dialects", expression = "java(this.map(languageService.getDialectsFor(language)))")
-	public abstract LanguageDto map(Language language);
+	@Mapping(target = "dialects", expression = "java(this.mapLanguageList(languageService.getDialectsFor(language)))")
+	@Mapping(target = "orthographies", expression = "java(orthographyService.getOrthographyDtosForLanguage(language))")
+	public abstract LanguageDto mapLanguageList(Language language);
 
-	public abstract List<LanguageDto> map(List<Language> languageList);
+	public abstract List<LanguageDto> mapLanguageList(List<Language> languageList);
 }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/mapper/LanguageMapper.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/mapper/LanguageMapper.java
@@ -4,7 +4,9 @@
 package dk.ule.oapenwb2.api.v1.abbreviations.mapper;
 
 import dk.ule.oapenwb.persistency.entity.content.basedata.Language;
+import dk.ule.oapenwb.persistency.entity.content.basedata.Orthography;
 import dk.ule.oapenwb2.api.v1.abbreviations.domain.LanguageDto;
+import dk.ule.oapenwb2.api.v1.abbreviations.domain.OrthographyDto;
 import dk.ule.oapenwb2.service.content.LanguageService;
 import dk.ule.oapenwb2.service.content.OrthographyService;
 import org.mapstruct.Mapper;
@@ -27,8 +29,13 @@ public abstract class LanguageMapper
 	@Mapping(target = "uitId", source = "uitID")
 	@Mapping(target = "uitIdAbbr", source = "uitID_abbr")
 	@Mapping(target = "dialects", expression = "java(this.mapLanguageList(languageService.getDialectsFor(language)))")
-	@Mapping(target = "orthographies", expression = "java(orthographyService.getOrthographyDtosForLanguage(language))")
+	@Mapping(target = "orthographies", expression = "java(mapOrthographyList(orthographyService.getOrthographiesForLanguage(language)))")
 	public abstract LanguageDto mapLanguageList(Language language);
 
 	public abstract List<LanguageDto> mapLanguageList(List<Language> languageList);
+
+	@Mapping(target = "uitId", source = "uitID")
+	public abstract OrthographyDto map(Orthography orthography);
+
+	public abstract List<OrthographyDto> mapOrthographyList(List<Orthography> orthographyList);
 }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/mapper/LevelMapper.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/api/v1/abbreviations/mapper/LevelMapper.java
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.api.v1.abbreviations.mapper;
+
+import dk.ule.oapenwb.persistency.entity.content.basedata.Level;
+import dk.ule.oapenwb2.api.v1.abbreviations.domain.LevelDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface LevelMapper
+{
+	@Mapping(target = "uitId", source = "uitID")
+	@Mapping(target = "abbreviatedUitId", source = "uitID_abbr")
+	LevelDto map(Level level);
+
+	List<LevelDto> mapLevelList(List<Level> levelList);
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/auditing/UserRevisionEntity.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/auditing/UserRevisionEntity.java
@@ -6,6 +6,8 @@ package dk.ule.oapenwb2.persistence.auditing;
 import dk.ule.oapenwb2.persistence.UserRevisionListener;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.envers.RevisionEntity;
 import org.hibernate.envers.RevisionNumber;
 import org.hibernate.envers.RevisionTimestamp;
@@ -18,8 +20,10 @@ import org.hibernate.envers.RevisionTimestamp;
  * same columns. The difference, however, is that each of the two entities uses a different
  * RevisionListener which is platform specific.</p>
  */
-@Data
+
 @Entity
+@Getter
+@Setter
 @Table(name = "RevInfos")
 @RevisionEntity(UserRevisionListener.class)
 public class UserRevisionEntity

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/CategoryRepository.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/CategoryRepository.java
@@ -7,7 +7,10 @@ import dk.ule.oapenwb.persistency.entity.content.basedata.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Integer>
 {
+	List<Category> findAllByParentID(Integer parentId);
 }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/LanguageRepositories.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/LanguageRepositories.java
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.persistence.content.basedata;
+
+import dk.ule.oapenwb.persistency.entity.content.basedata.Language;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LanguageRepositories extends JpaRepository<Language, Integer>
+{
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/LanguageRepository.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/LanguageRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface LanguageRepositories extends JpaRepository<Language, Integer>
+public interface LanguageRepository extends JpaRepository<Language, Integer>
 {
 }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/LanguageRepository.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/LanguageRepository.java
@@ -5,9 +5,16 @@ package dk.ule.oapenwb2.persistence.content.basedata;
 
 import dk.ule.oapenwb.persistency.entity.content.basedata.Language;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface LanguageRepository extends JpaRepository<Language, Integer>
 {
+	@Query("SELECT l FROM Language l WHERE l.parentID IS null ORDER BY l.localName")
+	List<Language> findAllTopLevelLanguages();
+
+	List<Language> findAllByParentIDOrderByLocalName(Integer parentID);
 }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/LevelRepository.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/LevelRepository.java
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.persistence.content.basedata;
+
+import dk.ule.oapenwb.persistency.entity.content.basedata.Level;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LevelRepository extends JpaRepository<Level, Integer>
+{
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/OrthographyRepository.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/OrthographyRepository.java
@@ -4,7 +4,6 @@
 package dk.ule.oapenwb2.persistence.content.basedata;
 
 import dk.ule.oapenwb.persistency.entity.content.basedata.Orthography;
-import dk.ule.oapenwb2.api.v1.abbreviations.domain.OrthographyDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -14,12 +13,13 @@ import java.util.List;
 @Repository
 public interface OrthographyRepository extends JpaRepository<Orthography, Integer>
 {
+	// ouk möäglik: new dk.ule.oapenwb2.api.v1.abbreviations.domain.OrthographyDto(o.abbreviation, o.uitID)
 	@Query(value = """
-		SELECT new dk.ule.oapenwb2.api.v1.abbreviations.domain.OrthographyDto(o.abbreviation, o.uitID)
+		SELECT o
 		FROM Orthography o
 		INNER JOIN LangOrthoMapping lo ON o.id=lo.orthographyID
 		INNER JOIN Language l ON lo.langID=l.id
 		WHERE l.id=?1
 		""")
-	List<OrthographyDto> findAllDtosByLangId(Integer langId);
+	List<Orthography> findAllDtosByLangId(Integer langId);
 }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/OrthographyRepository.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/OrthographyRepository.java
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.persistence.content.basedata;
+
+import dk.ule.oapenwb.persistency.entity.content.basedata.Orthography;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrthographyRepository extends JpaRepository<Orthography, Integer>
+{
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/OrthographyRepository.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/persistence/content/basedata/OrthographyRepository.java
@@ -4,10 +4,22 @@
 package dk.ule.oapenwb2.persistence.content.basedata;
 
 import dk.ule.oapenwb.persistency.entity.content.basedata.Orthography;
+import dk.ule.oapenwb2.api.v1.abbreviations.domain.OrthographyDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface OrthographyRepository extends JpaRepository<Orthography, Integer>
 {
+	@Query(value = """
+		SELECT new dk.ule.oapenwb2.api.v1.abbreviations.domain.OrthographyDto(o.abbreviation, o.uitID)
+		FROM Orthography o
+		INNER JOIN LangOrthoMapping lo ON o.id=lo.orthographyID
+		INNER JOIN Language l ON lo.langID=l.id
+		WHERE l.id=?1
+		""")
+	List<OrthographyDto> findAllDtosByLangId(Integer langId);
 }

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/service/content/CategoryService.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/service/content/CategoryService.java
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.service.content;
+
+import dk.ule.oapenwb.persistency.entity.content.basedata.Category;
+import dk.ule.oapenwb2.persistence.content.basedata.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class CategoryService
+{
+	private final CategoryRepository categoryRepository;
+
+	public List<Category> getAllTopLevelCategories() {
+		return this.categoryRepository.findAllByParentID(null);
+	}
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/service/content/LanguageService.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/service/content/LanguageService.java
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.service.content;
+
+import dk.ule.oapenwb.persistency.entity.content.basedata.Language;
+import dk.ule.oapenwb2.persistence.content.basedata.LanguageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LanguageService
+{
+	private final LanguageRepository languageRepository;
+
+	public List<Language> getAllLanguages() {
+		return this.languageRepository.findAllTopLevelLanguages();
+	}
+
+	public List<Language> getDialectsFor(Language language) {
+		return this.languageRepository.findAllByParentIDOrderByLocalName(language.getId());
+	}
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/service/content/LevelService.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/service/content/LevelService.java
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.service.content;
+
+import dk.ule.oapenwb.persistency.entity.content.basedata.Level;
+import dk.ule.oapenwb2.persistence.content.basedata.LevelRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class LevelService
+{
+	private final LevelRepository levelRepository;
+
+	public List<Level> getAllLevels() {
+		return levelRepository.findAll();
+	}
+}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/service/content/OrthographyService.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/service/content/OrthographyService.java
@@ -4,7 +4,7 @@
 package dk.ule.oapenwb2.service.content;
 
 import dk.ule.oapenwb.persistency.entity.content.basedata.Language;
-import dk.ule.oapenwb2.api.v1.abbreviations.domain.OrthographyDto;
+import dk.ule.oapenwb.persistency.entity.content.basedata.Orthography;
 import dk.ule.oapenwb2.persistence.content.basedata.OrthographyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,7 +17,7 @@ public class OrthographyService
 {
 	private final OrthographyRepository orthographyRepository;
 
-	public List<OrthographyDto> getOrthographyDtosForLanguage(Language language) {
+	public List<Orthography> getOrthographiesForLanguage(Language language) {
 		if (!"nds".equals(language.getLocale())) {
 			return null;
 		}

--- a/oapenwb-spring/src/main/java/dk/ule/oapenwb2/service/content/OrthographyService.java
+++ b/oapenwb-spring/src/main/java/dk/ule/oapenwb2/service/content/OrthographyService.java
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2024 Michael Köther <mkoether38@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package dk.ule.oapenwb2.service.content;
+
+import dk.ule.oapenwb.persistency.entity.content.basedata.Language;
+import dk.ule.oapenwb2.api.v1.abbreviations.domain.OrthographyDto;
+import dk.ule.oapenwb2.persistence.content.basedata.OrthographyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class OrthographyService
+{
+	private final OrthographyRepository orthographyRepository;
+
+	public List<OrthographyDto> getOrthographyDtosForLanguage(Language language) {
+		if (!"nds".equals(language.getLocale())) {
+			return null;
+		}
+		return this.orthographyRepository.findAllDtosByLangId(language.getId());
+	}
+}


### PR DESCRIPTION
oapenwb-spring:
- Added MapStruct dependenies and build plugin to POM.
- UserRevisionEntity: Exchanged `@Data` for `@Getter` and `@Setter`.
- Implemented AbbreviationsController.
    - Added endpoint '/languages' including DTO, mapper, and service.
    - Added endpoint '/categories' including DTO, mapper, and service.
    - Added endpoint '/levels' including DTO, mapper, and service.